### PR TITLE
Update image-size version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "image-size": "~0.1.16",
+    "image-size": "~0.3.0",
     "path": "~0.4.9",
     "mime": "~1.2.11"
   },


### PR DESCRIPTION
**image-size** has issues w/ some files that cause error. Fixes for that issues are in newer version.
Also check https://github.com/netroy/image-size/issues?utf8=%E2%9C%93&q=is%3Aissue+unsupported+
